### PR TITLE
Team WIlliam/Wilson fixed bugs

### DIFF
--- a/Sample_Shell_Script.sh
+++ b/Sample_Shell_Script.sh
@@ -11,4 +11,4 @@ echo ""
 
 # For this next bug, you may have to research options for the `sort` command using `$ man sort`
 echo "Alphabetically reverse-sorted list of words containing the string 'auto':"
-cat ~/dictionary.txt | grep auto | sort
+cat ~/dictionary.txt | grep auto | sort -r

--- a/Sample_Shell_Script.sh
+++ b/Sample_Shell_Script.sh
@@ -6,7 +6,7 @@ echo ""
 
 # To fix this, you need to filter the dictionary words
 echo "Number of words containing the string 'auto':"
-cat ~/dictionary.txt | FILL_ME_IN | wc --words
+cat ~/dictionary.txt | grep auto | wc --words
 echo ""
 
 # For this next bug, you may have to research options for the `sort` command using `$ man sort`


### PR DESCRIPTION
Fixed first bug by inserting "grep auto" to echo the amount of words containing the string "auto"
Fixed second bug by using "man sort" to find "sort -r" and echo an alphabetically reverse-sorted list